### PR TITLE
rpm: Remove version check for package dependencies

### DIFF
--- a/rpm/harbour-sailfishconnect.spec
+++ b/rpm/harbour-sailfishconnect.spec
@@ -30,13 +30,11 @@ BuildRequires:  pkgconfig(Qt5Feedback)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  pkgconfig(keepalive)
 BuildRequires:  cmake
+BuildRequires:  pkgconfig(python3)
 BuildRequires:  ninja
 BuildRequires:  gettext
-BuildRequires:  python3-devel
-%if "%(grep 'VERSION_ID' /etc/os-release | cut -d= -f2)" != "3.1.0.12"
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-pip
-%endif
 BuildRequires:  desktop-file-utils
 
 %description


### PR DESCRIPTION
It bugs builds on obs and that old release isn't used anymore anyway.